### PR TITLE
Ability to extend surveyor_gui functionality by decorator loading ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ A template library feature is pending.
 
 Surveyor_gui is mounted as an engine. Engine model and controller classes can be extended by open classing them in the main Rails application. Open classing an Engine class redefines it for use in the main application. This is usually implemented by using the decorator pattern. (from [rails guides](http://guides.rubyonrails.org/engines.html#improving-engine-functionality))
 
-Eg: For overriding module `SurveyfromsConrollerMethods`, 
+For overriding module `SurveyfromsConrollerMethods`, 
 
-Step 1. create file `surveyforms_conroller_methods_decorator.rb` under `app/decorators/modules/surveyor_gui`
+Step 1. Create file `surveyforms_conroller_methods_decorator.rb` under `app/decorators/modules/surveyor_gui`
 Step 2. For simple modificaions, consider `module_eval`, for complex modificaions, try `ActiveSupport::Concern`
 
 ###### Sample decorator code:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,35 @@ possible to mark certain parts of a survey as unmodifiable so that they will alw
   
 A template library feature is pending.
 
+## Overriding/Extending surveyor_gui functionality
+
+Surveyor_gui is mounted as an engine. Engine model and controller classes can be extended by open classing them in the main Rails application. Open classing an Engine class redefines it for use in the main application. This is usually implemented by using the decorator pattern. (from [rails guides](http://guides.rubyonrails.org/engines.html#improving-engine-functionality))
+
+Eg: For overriding module `SurveyfromsConrollerMethods`, 
+
+Step 1. create file `surveyforms_conroller_methods_decorator.rb` under `app/decorators/modules/surveyor_gui`
+Step 2. For simple modificaions, consider `module_eval`, for complex modificaions, try `ActiveSupport::Concern`
+
+###### Sample decorator code:
+```
+SurveyorGui::SurveyformsControllerMethods.module_eval do 
+  def create
+    params["surveyform"]["service_category"] = params["surveyform"]["service_category"].try(:to_i)
+    @surveyform = Surveyform.new(surveyforms_params.merge(user_id: @current_user.nil? ? @current_user : @current_user.id))
+    if @surveyform.save
+      flash[:notice] = I18n.t('create.success')
+      @title = "Edit Survey"
+      @question_no = 0
+      redirect_to edit_surveyform_path(@surveyform.id)
+    else
+      render :action => 'new'
+    end
+  end
+end
+```
+
+This code overrides `create` method defined in `SurveyformsControllerMethods` module.
+
 ## Test environment
 
 If you want to try out surveyor-gui before incorporating it into an application, or contribute, clone the repository.

--- a/lib/surveyor_gui/engine.rb
+++ b/lib/surveyor_gui/engine.rb
@@ -18,6 +18,11 @@ module SurveyorGui
       Dir.glob(root + "app/facades/*.rb").each do |c|
         require_dependency(c)
       end
+
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |decorator|
+        require_dependency(decorator)
+      end
+
       c = Dir.glob(File.expand_path('../',root)+'/app/controllers/surveyor_controller.rb').first
       require_dependency(c)
       Dir.glob(File.expand_path('../',root)+'/app/models/*.rb').each do |c|


### PR DESCRIPTION
I am using this gem in one of my projects with a slightly different use case other than creating surveys. One of the problems I faced while using this, is the difficulty to add/override default functionality given by the Surveyor::Gui engine.

I found that decorator pattern is used for this and this pull request adds this functionality such that users can override/extend functionality given by Survyor_gui engine in their parent rails app.